### PR TITLE
filter __constructor method

### DIFF
--- a/src/Router/DispatcherFactory.php
+++ b/src/Router/DispatcherFactory.php
@@ -116,6 +116,9 @@ class DispatcherFactory
 
         foreach ($publicMethods as $reflectionMethod) {
             $methodName = $reflectionMethod->getName();
+            if (strtolower($methodName) == '__construct') {
+                continue;
+            }
             $path = $this->pathGenerator->generate($prefix, $methodName);
             $router->addRoute($path, [
                 $className,


### PR DESCRIPTION
注册rpc方法时 过滤掉服务类的构造函数